### PR TITLE
Remove the need for the ugly cronjob workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,20 @@ does not exist anymore.
 Furthermore the statistics output of 
 `dsl_control dslstat` has an json output different to the outputs before.   
 
-Additionally the `collect-mod-exec` module, which allows to call user defined scripts, does not allow root access, which is neccessary to call `dsl_control dslstat`.   
+Additionally the `collect-mod-exec` module, which allows to call user defined scripts, does not allow root access, which is neccessary to call `dsl_control dslstat` or `ubus call dsl metrics`.
 
 ## The solution ##
-### Cronjob to get json data ###
-The entry    
-`* * * * * /etc/init.d/dsl_control dslstat > /tmp/dslstat.txt`   
-in **Scheduled Tasks** writes the json output to ram (actually file `/tmp/dslstat.txt`). Also it might be needed to restart the cron service.   
+### Whitelisting the ubus call ###
+Copy the file `dsl.json` to `/usr/share/acl.d/dsl.json`.
+This allows the `dsl_stats.sh` script to read the dsl metrics as user nobody.
+I don't know how to apply this change without rebooting, so just do that.
    
 ### Filling the rrd database ### 
-The script `dsl_stats.sh`, that is called by the module `collect-mod-exec`, decodes the json format of the data using the library `/usr/share/libubox/jshn.sh`.   
+The script `dsl_stats.sh`, which is called by the module `collect-mod-exec`, decodes the json format of the data using the library `/usr/share/libubox/jshn.sh`.
    
 You can save the script wherever you want, but better not in folders that do not survive a reboot.
 I mounted a usb-stick to also keep my statistics data there. That is also my place for the script. 
-Also do not forget to give it execution permissions and make it accessable by nobody:nogroup
-`chmod 777 dsl_stats.sh`
-`chmod +x dsl_stats.sh`   
+Also do not forget to make it executable by user nobody: `chmod +x dsl_stats.sh`.
   
    
 ### Creating the graphs ###

--- a/dsl.json
+++ b/dsl.json
@@ -1,0 +1,8 @@
+{
+	"user": "nobody",
+	"access": {
+		"dsl": {
+			"methods": [ "metrics" ]
+		}
+	}
+}

--- a/dsl_stats.sh
+++ b/dsl_stats.sh
@@ -16,9 +16,7 @@ INTERVAL=$COLLECTD_INTERVAL
 INTERVAL=$(awk -v i=$INTERVAL 'BEGIN{print int(i)}')
 
 while sleep $INTERVAL; do
-  ## Status aus Datei laden, direkte Befehlsausfuehrung wg. erforderlichem root nicht moeglich
-  #json_load "$(/etc/init.d/dsl_control dslstat)"
-  json_load_file /tmp/dslstat.txt
+  json_load "$(ubus call dsl metrics)"
   
   ## Uptime
   json_get_var upt uptime


### PR DESCRIPTION
Instead of calling `/etc/init.d/dsl_control dslstat`, use `ubus call dsl metrics`, which gives the same output and allows whitelisting of specific ubus calls for the user nobody.
Also make some minor adjustments to the sentence describing how to make the script executable.